### PR TITLE
fix: remove documentSymbols error

### DIFF
--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -308,7 +308,6 @@ end
 
 function M.attach(client, bufnr)
 	if not client.server_capabilities.documentSymbolProvider then
-		vim.notify("nvim-navic: Server " .. client.name .. " does not support documentSymbols", vim.log.levels.ERROR)
 		return
 	end
 


### PR DESCRIPTION
I think most reasonable servers support documentSymbols and for those that don't support it like `tailwindcss` and `eslint` this error is just annoying because every time I open a tsx file they popup on my screen.
related #7