### PR TITLE
feat: Add option log_level

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Use the `setup` function to modify default parameters.
 * `highlight` : If set to true, will add colors to icons and text as defined by highlight groups `NavicIcons*` (`NavicIconsFile`, `NavicIconsModule`.. etc.), `NavicText` and `NavicSeparator`.
 * `depth_limit` : Maximum depth of context to be shown. If the context hits this depth limit, it is truncated.
 * `depth_limit_indicatior` : Icon to indicate that `depth_limit` was hit and the shown context is truncated.
+* `log_level` : Maximum log level to log (`vim.log.levels`), `-1` to disable logging.
 
 ```lua
 navic.setup {
@@ -90,6 +91,7 @@ navic.setup {
     separator = " > ",
     depth_limit = 0,
     depth_limit_indicator = "..",
+    log_level = vim.log.levels.TRACE,
 }
 
 ```

--- a/doc/navic.txt
+++ b/doc/navic.txt
@@ -119,6 +119,9 @@ Use *navic.setup* to override any of the default options
 	depth_limit_indicator: string
 		Indicator signifing that displayed string is truncated.
 
+    log_level: number
+        Maximum log level to log (vim.log.levels), -1 to disable logging.
+
 Defaults >
 	navic.setup {
 		icons = {
@@ -153,6 +156,7 @@ Defaults >
 		separator = " > ",
 		depth_limit = 0,
 		depth_limit_indicator = "..",
+        log_level = vim.log.levels.TRACE,
 	}
 <
 

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -1,6 +1,49 @@
 local M = {}
 
 -- @Private Methods
+local config = {
+	icons = {
+		[1] = " ", -- File
+		[2] = " ", -- Module
+		[3] = " ", -- Namespace
+		[4] = " ", -- Package
+		[5] = " ", -- Class
+		[6] = " ", -- Method
+		[7] = " ", -- Property
+		[8] = " ", -- Field
+		[9] = " ", -- Constructor
+		[10] = "練", -- Enum
+		[11] = "練", -- Interface
+		[12] = " ", -- Function
+		[13] = " ", -- Variable
+		[14] = " ", -- Constant
+		[15] = " ", -- String
+		[16] = " ", -- Number
+		[17] = "◩ ", -- Boolean
+		[18] = " ", -- Array
+		[19] = " ", -- Object
+		[20] = " ", -- Key
+		[21] = "ﳠ ", -- Null
+		[22] = " ", -- EnumMember
+		[23] = " ", -- Struct
+		[24] = " ", -- Event
+		[25] = " ", -- Operator
+		[26] = " ", -- TypeParameter
+	},
+	highlight = false,
+	separator = " > ",
+	depth_limit = 0,
+	depth_limit_indicator = "..",
+	log_level = vim.log.levels.TRACE,
+}
+
+local function log(text, log_level)
+	if (config.log_level == -1) then return end
+
+	if (log_level >= config.log_level) then
+		vim.notify(text, log_level)
+	end
+end
 
 -- Make request to lsp server
 local function request_symbol(for_buf, handler, client_id)
@@ -28,7 +71,7 @@ local function parse(symbols)
 
 			-- SymbolInformation detection
 			if val.range == nil then
-				vim.notify(
+				log(
 					'nvim-navic: Server "'
 						.. vim.lsp.get_client_by_id(vim.b.navic_client_id).name
 						.. '" does not support documentSymbols, it is responds with SymbolInformation format which has been deprecated in latest LSP specification.',
@@ -210,41 +253,6 @@ local lsp_num_to_str = {
 	[26] = "TypeParameter",
 }
 
-local config = {
-	icons = {
-		[1] = " ", -- File
-		[2] = " ", -- Module
-		[3] = " ", -- Namespace
-		[4] = " ", -- Package
-		[5] = " ", -- Class
-		[6] = " ", -- Method
-		[7] = " ", -- Property
-		[8] = " ", -- Field
-		[9] = " ", -- Constructor
-		[10] = "練", -- Enum
-		[11] = "練", -- Interface
-		[12] = " ", -- Function
-		[13] = " ", -- Variable
-		[14] = " ", -- Constant
-		[15] = " ", -- String
-		[16] = " ", -- Number
-		[17] = "◩ ", -- Boolean
-		[18] = " ", -- Array
-		[19] = " ", -- Object
-		[20] = " ", -- Key
-		[21] = "ﳠ ", -- Null
-		[22] = " ", -- EnumMember
-		[23] = " ", -- Struct
-		[24] = " ", -- Event
-		[25] = " ", -- Operator
-		[26] = " ", -- TypeParameter
-	},
-	highlight = false,
-	separator = " > ",
-	depth_limit = 0,
-	depth_limit_indicator = "..",
-}
-
 -- @Public Methods
 
 function M.setup(opts)
@@ -260,6 +268,7 @@ function M.setup(opts)
 	config.depth_limit = opts.depth_limit or config.depth_limit
 	config.depth_limit_indicator = opts.depth_limit_indicator or config.depth_limit_indicator
 	config.highlight = opts.highlight or config.highlight
+	config.log_level = opts.log_level or config.log_level
 end
 
 -- returns table of context or nil
@@ -331,13 +340,13 @@ end
 
 function M.attach(client, bufnr)
 	if not client.server_capabilities.documentSymbolProvider then
-		vim.notify('nvim-navic: Server "' .. client.name .. '" does not support documentSymbols.', vim.log.levels.ERROR)
+		log('nvim-navic: Server "' .. client.name .. '" does not support documentSymbols.', vim.log.levels.ERROR)
 		return
 	end
 
 	if vim.b.navic_client_id ~= nil and vim.b.navic_client_name ~= client.name then
 		local prev_client = vim.lsp.get_client_by_id(client.id)
-		vim.notify(
+		log(
 			"nvim-navic: Failed to attach to "
 				.. client.name
 				.. " for current buffer. Already attached to "

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -264,11 +264,11 @@ function M.setup(opts)
 		end
 	end
 
-	config.separator = opts.separator or config.separator
-	config.depth_limit = opts.depth_limit or config.depth_limit
-	config.depth_limit_indicator = opts.depth_limit_indicator or config.depth_limit_indicator
-	config.highlight = opts.highlight or config.highlight
-	config.log_level = opts.log_level or config.log_level
+	if opts.separator ~= nil then config.separator = opts.separator end
+	if opts.depth_limit ~= nil then config.depth_limit = opts.depth_limit end
+	if opts.depth_limit_indicator ~= nil then config.depth_limit_indicator = opts.depth_limit_indicator end
+	if opts.highlight ~= nil then config.highlight = opts.highlight end
+	if opts.log_level ~= nil then config.log_level = opts.log_level end
 end
 
 -- returns table of context or nil


### PR DESCRIPTION
Adds the option `log_level` which can be set to any value within `vim.log.levels` to limit logging up to that level.
Can also be set to `-1` to disable logging entirely.
~~Also fixed minor typos in readme and help doc.~~