### PR TITLE
enhancement: add navic scope data

### DIFF
--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -317,6 +317,7 @@ function M.get_data()
 			type = lsp_num_to_str[v.kind],
 			name = v.name,
 			icon = config.icons[v.kind],
+			scope = v.scope
 		})
 	end
 


### PR DESCRIPTION
This adds the scope data which include the line and column information for each symbol. This is helpful for plugin users to create keybindings or commands to jump to these symbols. 

Sample output for get_data() with this change: 

```lua
{{
  icon = " ",
  kind = 12,
  name = "M.explorer",
  scope = {
    end = {
      character = 3,
      line = 471
    },
    start = {
      character = 0,
      line = 108
    }
  },
  type = "Function"
}, {
    icon = " ",
    kind = 12,
    name = "self.panel_show",
    scope = {
      end = {
        character = 5,
        line = 315
      },
      start = {
        character = 2,
        line = 251
      }
    },
    type = "Function"
  }
}

```