### PR TITLE
Document a way to mitigate errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,18 @@ require("lspconfig").clangd.setup {
 }
 ```
 
+If you're sharing your `on-attach` function between lspconfigs, better wrap nvim-navic's `attach` function to make sure `documentSymbolProvider` is enabled:
+
+Example:
+```lua
+local on_attach = function(client, bufnr)
+  ...
+  if client.server_capabilities.documentSymbolProvider then
+    navic.attach(client, bufnr)
+  end
+  ...
+end
+
 >NOTE: You can set `vim.g.navic_silence = true` to supress error messages thrown by nvim-navic. However this is not recommended as the error messages indicate that there is problem in your setup. That is, you are attaching nvim-navic to servers that don't support documentSymbol or are attaching navic to multiple servers for a single buffer.
 
 ## 🪄 Customise

--- a/README.md
+++ b/README.md
@@ -52,12 +52,16 @@ If you're sharing your `on-attach` function between lspconfigs, better wrap nvim
 Example:
 ```lua
 local on_attach = function(client, bufnr)
-  ...
-  if client.server_capabilities.documentSymbolProvider then
-    navic.attach(client, bufnr)
-  end
-  ...
+    ...
+    if client.server_capabilities.documentSymbolProvider then
+        navic.attach(client, bufnr)
+    end
+    ...
 end
+
+require("lspconfig").clangd.setup {
+    on_attach = on_attach
+}
 ```
 
 >NOTE: You can set `vim.g.navic_silence = true` to supress error messages thrown by nvim-navic. However this is not recommended as the error messages indicate that there is problem in your setup. That is, you are attaching nvim-navic to servers that don't support documentSymbol or are attaching navic to multiple servers for a single buffer.

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ local on_attach = function(client, bufnr)
   end
   ...
 end
+```
 
 >NOTE: You can set `vim.g.navic_silence = true` to supress error messages thrown by nvim-navic. However this is not recommended as the error messages indicate that there is problem in your setup. That is, you are attaching nvim-navic to servers that don't support documentSymbol or are attaching navic to multiple servers for a single buffer.
 


### PR DESCRIPTION
It's better to document this if, for a case where a user is using an `on-attach` function for all lspconfigs he has.
Most users do that, and this if block can help a lot