### PR TITLE
docs: fix lualine example

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ local navic = require("nvim-navic")
 require("lualine").setup({
     sections = {
         lualine_c = {
-            { { navic.get_location, cond = navic.is_available } },
+            { navic.get_location, cond = navic.is_available },
         }
     }
 })


### PR DESCRIPTION
I tried the example setup for lualine (in the newest version) and it resulted in an error. After some digging I found out there is a redundant nested table in the example setup, and it works without it.