### PR TITLE
Setup depth limit accept function

### DIFF
--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -498,14 +498,31 @@ function M.get_location(opts)
 		end
 	end
 
-	if local_config.depth_limit ~= 0 and #location > local_config.depth_limit then
+  if local_config.depth_limit == "auto" then
+    local remove_counter = 0
+    while
+      table.concat(
+        location,
+        (local_config.highlight and "%#NavicSeparator#" or '')
+        .. local_config.separator
+        .. (local_config.highlight and "%*" or ""))
+      :len() > vim.api.nvim_win_get_width(0) do
+      location = vim.list_slice(location, 1, #location)
+      remove_counter = remove_counter + 1
+    end
+    if remove_counter and local_config.highlight then
+			table.insert(location, 1, "%#NavicSeparator#" .. local_config.depth_limit_indicator .. "%*")
+		else
+			table.insert(location, 1, local_config.depth_limit_indicator)
+    end
+  elseif local_config.depth_limit ~= 0 and #location > local_config.depth_limit then
 		location = vim.list_slice(location, #location - local_config.depth_limit + 1, #location)
 		if local_config.highlight then
 			table.insert(location, 1, "%#NavicSeparator#" .. local_config.depth_limit_indicator .. "%*")
 		else
 			table.insert(location, 1, local_config.depth_limit_indicator)
 		end
-	end
+  end
 
 	local ret = ""
 

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -498,48 +498,49 @@ function M.get_location(opts)
 		end
 	end
 
-  if type(local_config.depth_limit) == "function" then
-    local context = {
-      winid = vim.api.nvim_get_current_win(),
-      path = vim.fn.expand('%:p'),
-      mod = vim.bo.mod,
-    }
-    if type(local_config.depth_limit(context)) == "number" then
-      local start_index = 0
-      while
-        table.concat(
-          vim.list_slice(location, start_index + 1, #location),
-          (local_config.highlight and "%#NavicSeparator#" or '')
-          .. local_config.separator
-          .. (local_config.highlight and "%*" or ""))
-        :len() > local_config.depth_limit(context) do
-        start_index = start_index + 1
-      end
-      location = vim.list_slice(location, start_index, #location)
-      if start_index > 1 then
-        if local_config.highlight then
-          table.insert(location, 1, "%#NavicSeparator#" .. local_config.depth_limit_indicator .. "%*")
-        else
-          table.insert(location, 1, local_config.depth_limit_indicator)
-        end
-      end
-    else
-      local_config.depth_limit = 0
-    end
-  end
+	if type(local_config.depth_limit) == "function" then
+		local context = {
+			winid = vim.api.nvim_get_current_win(),
+			path = vim.fn.expand('%:p'),
+			mod = vim.bo.mod,
+		}
+		if type(local_config.depth_limit(context)) == "number" then
+			local start_index = 0
+			while
+				table.concat(
+				vim.list_slice(location, start_index + 1, #location),
+					(local_config.highlight and "%#NavicSeparator#" or '')
+					.. local_config.separator
+					.. (local_config.highlight and "%*" or ""))
+				:len() > local_config.depth_limit(context)
+			do
+				start_index = start_index + 1
+			end
+			location = vim.list_slice(location, start_index, #location)
+			if start_index > 1 then
+				if local_config.highlight then
+					table.insert(location, 1, "%#NavicSeparator#" .. local_config.depth_limit_indicator .. "%*")
+				else
+					table.insert(location, 1, local_config.depth_limit_indicator)
+				end
+			end
+		else
+			local_config.depth_limit = 0
+		end
+	end
 
-  if type(local_config.depth_limit) == "number"
-    and local_config.depth_limit ~= 0 and #location > local_config.depth_limit then
-    local start_index = #location - local_config.depth_limit + 1
+	if type(local_config.depth_limit) == "number"
+		and local_config.depth_limit ~= 0 and #location > local_config.depth_limit then
+		local start_index = #location - local_config.depth_limit + 1
 		location = vim.list_slice(location, start_index, #location)
-    if start_index > 1 then
-      if local_config.highlight then
-        table.insert(location, 1, "%#NavicSeparator#" .. local_config.depth_limit_indicator .. "%*")
-      else
-        table.insert(location, 1, local_config.depth_limit_indicator)
-      end
-    end
-  end
+		if start_index > 1 then
+			if local_config.highlight then
+				table.insert(location, 1, "%#NavicSeparator#" .. local_config.depth_limit_indicator .. "%*")
+			else
+				table.insert(location, 1, local_config.depth_limit_indicator)
+			end
+		end
+	end
 
 	local ret = ""
 

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -508,10 +508,12 @@ function M.get_location(opts)
 			local start_index = 0
 			while
 				table.concat(
-				vim.list_slice(location, start_index + 1, #location),
+					vim.list_slice(location, start_index + 1, #location),
 					(local_config.highlight and "%#NavicSeparator#" or '')
 					.. local_config.separator
 					.. (local_config.highlight and "%*" or ""))
+				:gsub('%%#%a+#', '')
+				:gsub('%%', ''):gsub('%*', '')
 				:len() > local_config.depth_limit(context)
 			do
 				start_index = start_index + 1


### PR DESCRIPTION
## Description

In short, I was thinking about how to achieve auto-depth-limit effect based on the width of the current window to make use of the WinBar as much as possible. I believe this will be a good enhancement for anyone.


## Setup

With this (partial) config:

```lua
config = function ()
  local navic = require('nvim-navic')
  navic.setup{
    depth_limit = function (context)
      return vim.api.nvim_win_get_width(context.winid)
        - string.format('%s%s  ', vim.fn.fnamemodify(context.path, ':t'), context.mod and '*' or ''):len()
    end,
  }
```

where I define the `context` to have these data that a user **cannot** get itself in the `depth_limit` function:

```lua
{
  winid = vim.api.nvim_get_current_win(), -- the current window id.
  path = vim.fn.expand('%:p'), -- full path of the current file.
  mod = vim.bo.mod, -- whether or not the current file is modified.
}
```

and `autocmd` like this:

```lua
vim.api.nvim_create_autocmd({ 'CursorHold', 'InsertEnter' }, {
  callback = function()
    if should_exclude[vim.bo.filetype] or should_exclude[vim.bo.buftype] then return end
    local winbar_prefix = string.format('%s%s  ', vim.fn.expand('%:t'), vim.bo.mod and '*' or '')
    local winbar_content = navic.is_available and navic.get_location() or ''
    vim.wo.winbar = winbar_prefix .. winbar_content
  end,
})
```

Then we can achieve the effect as DEMO:

- If the content of WinBar from nvim-navic exceeds the return value of `depth_limit`, the `depth_limit_indicator` will be used to fold the content in a leave-less-space manner. (The old behavior: a fixed depth is used. It's very likely to **waste** the space of WinBar.)
- If not, then the full content of WinBar from nvim-navic will be used instead, without the `depth_limit_indicator`. (In the DEMO, I use my own plugin to create a floating window with larger width for the current buffer my cursor is on.)
    
    <img src="https://user-images.githubusercontent.com/24765272/211447029-26324bbc-e144-43af-bd05-adfce126dbd6.png" width="600">
    <img src="https://user-images.githubusercontent.com/24765272/211446991-ca5de1ca-8ec3-4868-8192-76149ca74473.png" width="750">


https://user-images.githubusercontent.com/24765272/211439858-a962289c-2995-4af8-976d-993e8cd66bdb.mov

---

## Notes:

- This PR doesn't include any modification of the docs. I need your help on this.
- While this change is backward-compatible, I also added some fixes to the current implementation so that it's more logically correct, i.e. the two `start_index > 1` checks to make sure that `depth_limit_indicator` will only be shown when it should.
- You might have a better idea of variable naming.

Thanks for your reading.