### PR TITLE
Add bufnr option to get_location

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ navic.setup {
 nvim-navic does not alter your statusline or winbar on its own. Instead, you are provided with these two functions and its left up to you how you want to incorporate this into your setup.
 
 * `is_available(bufnr)` : Returns boolean value indicating whether output can be provided. `bufnr` is optional, default is current.
-* `get_location(opts)`  : Returns a pretty string with context information. Using `opts` table you can override any of the options, format same as the table for `setup` function.
+* `get_location(opts, bufnr)`  : Returns a pretty string with context information. Using `opts` table you can override any of the options, format same as the table for `setup` function. You can also provide a `bufnr` value to determine which buffer is used to get the code context information, if not provided the current buffer will be used.
 
 <details>
 <summary>Examples</summary>

--- a/doc/navic.txt
+++ b/doc/navic.txt
@@ -34,11 +34,13 @@ API                                                                 *navic-api*
 	'bufnr' is optional argument. If bufnr is not provied, current open
 	buffer is used.
 
-*navic.get_location* (opts)
+*navic.get_location* (opts, bufnr)
 	Returns a pretty string that shows code context and can be used directly
 	in statusline or winbar.
 	opts table can be passed to override any of |nvim-navic|'s options.
-	Follows same table format as *navic-setup*|'s opts table.
+    Follows same table format as *navic-setup*|'s opts table. You can pass
+    |bufnr| value to determine which buffer is used to get code context. If
+    not provided, the current buffer will be used.
 
 *navic.get_data* (bufnr)
 	Returns a table of tables representing the current code context. Contains

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -439,7 +439,7 @@ function M.is_available(bufnr)
 	return vim.b[bufnr].navic_client_id ~= nil
 end
 
-function M.get_location(opts)
+function M.get_location(opts, bufnr)
 	local local_config = {}
 
 	if opts ~= nil then
@@ -472,7 +472,7 @@ function M.get_location(opts)
 		local_config = config
 	end
 
-	local data = M.get_data()
+	local data = M.get_data(bufnr)
 
 	if data == nil then
 		return ""


### PR DESCRIPTION
Using this option, one can display the last available code context information when using `:help winbar` option to display code context. Without this, since it's using the current buffer always, the other windows will display wrong information.