### PR TITLE
fix: Handle curr.children nil case

### DIFF
--- a/lua/nvim-navic/lib.lua
+++ b/lua/nvim-navic/lib.lua
@@ -322,6 +322,7 @@ function M.update_context(for_buf, arg_cursor_pos)
 		end
 		if
 			in_range(cursor_pos, context.scope) == 0
+			and curr.children ~= nil
 			and curr.children[context.index] ~= nil
 			and context.name == curr.children[context.index].name
 			and context.kind == curr.children[context.index].kind


### PR DESCRIPTION
Hi, thanks for the great plugin.

This is a simple fix to handle an edge-case I've seen when working in Go. This silences the errors that are otherwise thrown when `curr.children` is `nil`.
