### PR TITLE
feat: automatically attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Plug "SmiteshP/nvim-navic"
 
 ## ⚙️ Setup
 
-For nvim-navic to work, it needs attach to the lsp server. You can pass the nvim-navic's `attach` function as `on_attach` while setting up the lsp server.
+For nvim-navic to work, it needs attach to the lsp server. You can pass the nvim-navic's `attach` function as `on_attach` while setting up the lsp server. You can skip this step if you have enabled auto_attach option during setup.
 
 Note: nvim-navic can attach to only one server per buffer.
 
@@ -79,6 +79,10 @@ Use the `setup` function to modify default parameters.
 * `depth_limit` : Maximum depth of context to be shown. If the context hits this depth limit, it is truncated.
 * `depth_limit_indicator` : Icon to indicate that `depth_limit` was hit and the shown context is truncated.
 * `safe_output` : Sanitize the output for use in statusline and winbar.
+* `lsp` :
+    * `auto_attach` : Enable to have nvim-navic automatically attach to every LSP for current buffer. Its disabled by default.
+    * `preference` : Table ranking lsp_servers. Lower the index, higher the priority of the server. If there are more than one server attached to a buffer, nvim-navic will refer to this list to make a decision on which one to use.
+			For example - In case a buffer is attached to clangd and ccls both and the preference list is `{ "clangd", "pyright" }`. Then clangd will be preferred.
 
 ```lua
 navic.setup {
@@ -109,6 +113,10 @@ navic.setup {
         Event         = " ",
         Operator      = " ",
         TypeParameter = " ",
+    },
+    lsp = {
+        auto_attach = false,
+        preference = nil,
     },
     highlight = false,
     separator = " > ",

--- a/doc/navic.txt
+++ b/doc/navic.txt
@@ -54,7 +54,8 @@ API                                                                 *navic-api*
 Usage                                                             *navic-usage*
 
 |nvim-navic| needs to be attached to lsp servers of the buffer to work. Use the
-|navic.attach| function while setting up lsp servers.
+|navic.attach| function while setting up lsp servers. You can skip this step
+if you have enabled auto_attach option during setup.
 
 NOTE: You can attach to only one lsp server per buffer.
 
@@ -161,6 +162,19 @@ Use |navic.setup| to override any of the default options
 	safe_output: boolean
 		Sanitize the output for use in statusline and winbar.
 
+	lsp :
+		auto_attach: boolean
+			Enable to have nvim-navic automatically attach to every LSP for
+			current buffer. Its disabled by default.
+		preference: table
+			Table ranking lsp_servers. Lower the index, higher the priority of
+			the server. If there are more than one server attached to a
+			buffer, nvim-navic will refer to this list to make a decision on
+			which one to use.
+			For example - In case a buffer is attached to clangd and ccls both
+			and the preference list is `{ "clangd", "pyright" }`. Then clangd
+			will be preferred.
+
 Defaults >
 	navic.setup {
 		icons = {
@@ -190,6 +204,10 @@ Defaults >
 			Event         = " ",
 			Operator      = " ",
 			TypeParameter = " ",
+		},
+		lsp = {
+			auto_attach = false,
+			preference = nil,
 		},
 		highlight = false,
 		separator = " > ",

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -241,7 +241,7 @@ function M.attach(client, bufnr)
 			if not awaiting_lsp_response[bufnr] and changedtick < vim.b[bufnr].changedtick then
 				awaiting_lsp_response[bufnr] = true
 				changedtick = vim.b[bufnr].changedtick
-				lib.request_symbol(bufnr, lsp_callback, client.id)
+				lib.request_symbol(bufnr, lsp_callback, client)
 			end
 		end,
 		group = navic_augroup,
@@ -273,7 +273,7 @@ function M.attach(client, bufnr)
 
 	-- First call
 	vim.b[bufnr].navic_awaiting_lsp_response = true
-	lib.request_symbol(bufnr, lsp_callback, client.id)
+	lib.request_symbol(bufnr, lsp_callback, client)
 end
 
 return M

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -39,6 +39,10 @@ local config = {
 	depth_limit = 0,
 	depth_limit_indicator = "..",
 	safe_output = true,
+	lsp = {
+		auto_attach = false,
+		preference = nil
+	}
 }
 
 setmetatable(config.icons, {
@@ -60,7 +64,7 @@ local function setup_auto_attach(opts)
 				return M.attach(client, args.buf)
 			end
 
-			if not opts.preference then
+			if not opts.lsp.preference then
 				return vim.notify(
 					"nvim-navic: Trying to attach "
 						.. client.name
@@ -71,7 +75,7 @@ local function setup_auto_attach(opts)
 				)
 			end
 
-			for _, preferred_lsp in ipairs(opts.preference) do
+			for _, preferred_lsp in ipairs(opts.lsp.preference) do
 				-- If new client comes first, then remove the previous
 				-- attached server and attatch the new one
 				if preferred_lsp == client.name then
@@ -93,7 +97,7 @@ function M.setup(opts)
 		return
 	end
 
-	if opts.auto_attach then
+	if opts.lsp ~= nil and opts.lsp.auto_attach then
 		setup_auto_attach(opts)
 	end
 


### PR DESCRIPTION
# Problem

It feels unecessary to manually setup nvim-navic even when calling the setup function of nvim-navic.

# Solution

Make it automatically attach to a language server if it supports `documentSymbolProvider` by using the `LspAttach` autocmd.
A user could opt-in to this by using `auto_attach = true` in the setup table.

# Context

It looks like others want it too judging from these issues:

https://github.com/SmiteshP/nvim-navic/issues/11
https://github.com/folke/lazy.nvim/issues/704