### PR TITLE
chore: modify documentation.

### DIFF
--- a/doc/navic.txt
+++ b/doc/navic.txt
@@ -152,7 +152,7 @@ Use |navic.setup| to override any of the default options
 	separator: string
 		Icon to be used to separate two symbols.
 
-	depth: integer
+	depth_limit: integer
 		Maximum depth of context to be shown. If the context depth exceeds
 		this parameter, context information is truncated. default is infinite
 


### PR DESCRIPTION
Hello!

This is very minor, but I noticed that the option names in the document are not up to date.

`depth` -> `depth_limit`

I think it is correct to align with `README.md` 😄

I always use nvim-navic, thanks!