### PR TITLE
fix: only trigger navbuddy on double click

### DIFF
--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -218,7 +218,7 @@ function M.get_location(opts, bufnr)
 				data[minwid].scope["start"].line,
 				data[minwid].scope["start"].character
 			})
-			if cnt >= 1 then
+			if cnt > 1 then
 				local ok, navbuddy = pcall(require, "nvim-navbuddy")
 				if ok then
 					navbuddy.open(bufnr)


### PR DESCRIPTION
The docs state that navbuddy is triggered on double click, but I get a warning when I single click.
