### PR TITLE
feat: mark jumplist before moving to symbol on click

### DIFF
--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -214,6 +214,7 @@ function M.get_location(opts, bufnr)
 
 	if local_config.click then
 		_G.navic_click_handler = function(minwid, cnt, _, _)
+			vim.cmd.normal("m'")
 			vim.api.nvim_win_set_cursor(0, {
 				data[minwid].scope["start"].line,
 				data[minwid].scope["start"].character


### PR DESCRIPTION
I tried out this new feature and found that it doesn't add to the jump list, so ctrl-o and ctrl-i do not work.

This marks the location before moving the cursor, and works how I expected it to.
