### PR TITLE
Add default icon highlight group

### DIFF
--- a/doc/navic.txt
+++ b/doc/navic.txt
@@ -288,6 +288,7 @@ Highlight                                                    *navic-highlights*
 |nvim-navic| provides the following highlights which get used when highlight
 option is set to `true`.
 
+	`NavicIcon`
 	`NavicIconsFile`
 	`NavicIconsModule`
 	`NavicIconsNamespace`
@@ -316,6 +317,10 @@ option is set to `true`.
 	`NavicIconsTypeParameter`
 	`NavicText`
 	`NavicSeparator`
+
+The `NavicIcons*` groups all link to `NavicIcon` by default.  Set `NavicIcon`
+to change the highlight for all icons together, then override individual
+`NavicIcons*` groups with specific highlights.
 
 =============================================================================
 vim:tw=78:ts=4:ft=help:norl:

--- a/lua/nvim-navic/lib.lua
+++ b/lua/nvim-navic/lib.lua
@@ -431,4 +431,10 @@ function M.adapt_lsp_num_to_str(n)
 	return lsp_num_to_str[n]
 end
 
+vim.api.nvim_set_hl(0, 'NavicIcon', {default = true, link = 'StatusLine'})
+for kind in pairs(lsp_str_to_num) do
+	local hlgroup = string.format('NavicIcons%s', kind)
+	vim.api.nvim_set_hl(0, hlgroup, {default = true, link = 'NavicIcon'})
+end
+
 return M


### PR DESCRIPTION
As a user I want the same highlighting for all or at least most of the icons. I
then want to be able to individually override only some icons (if any).

This PR adds the default highlight group `NavicIcon` which all other icon
highlight groups link to. Let's say I want to highlight only classes with red
text and all other icons with blue text. I can now write the following in my
configuration:

```vim
highlight NavicIcon       guifg=blue
highlight NavicIconsClass guifg=red
```

This is much easier on the eye than having to repeat essentially the same
definition 25 times.

I have chosen `StatusLine` as the default for `NavicIcon` as that appeared to
be the most reasonable default choice. Maybe you have a better idea?
