### PR TITLE
Feat/lazy update context

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ require("lspconfig").clangd.setup {
 
 >NOTE: You can set `vim.g.navic_silence = true` to supress error messages thrown by nvim-navic. However this is not recommended as the error messages indicate that there is problem in your setup. That is, you are attaching nvim-navic to servers that don't support documentSymbol or are attaching navic to multiple servers for a single buffer.
 
->NOTE: You can set `vim.b.navic_lazy_update_context = true` for specific buffers, where you want the the updates to not occur on every `CursorMoved` event. It should help if you are facing performance issues in large files. Read the docs for example usage of this variable. Alternatively, you can pass `lazy_update_context=true` to the `setup` function to turn off updates on the "CursorMoved" event completely.
+>NOTE: You can set `vim.b.navic_lazy_update_context = true` for specific buffers, where you want the the updates to not occur on every `CursorMoved` event. It should help if you are facing performance issues in large files. Read the docs for example usage of this variable. Alternatively, you can pass `lazy_update_context=true` to the `setup` function to turn off updates on the `CursorMoved` event completely.
 
 ## 🪄 Customise
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ require("lspconfig").clangd.setup {
 
 >NOTE: You can set `vim.g.navic_silence = true` to supress error messages thrown by nvim-navic. However this is not recommended as the error messages indicate that there is problem in your setup. That is, you are attaching nvim-navic to servers that don't support documentSymbol or are attaching navic to multiple servers for a single buffer.
 
->NOTE: You can set `vim.b.navic_lazy_update_context = true` for specific buffers, where you want the the updates to not occur on every `CursorMoved` event. It should help if you are facing performance issues in large files. Read the docs for example usage of this variable. Alternatively, you can pass `lazy_update_context=true` to the `setup` function to turn off updates on the `CursorMoved` event completely.
+>NOTE: You can set `vim.b.navic_lazy_update_context = true` for specific buffers, where you want the the updates to not occur on every `CursorMoved` event. It should help if you are facing performance issues in large files. Read the docs for example usage of this variable. Alternatively, you can pass `lazy_update_context=true` to the `setup` function to turn off context updates on the `CursorMoved` event completely for all buffers. It's useful when you just want context updates to happen only on `CursorHold` events and not on `CursorMoved`.
 
 ## 🪄 Customise
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ require("lspconfig").clangd.setup {
 
 >NOTE: You can set `vim.g.navic_silence = true` to supress error messages thrown by nvim-navic. However this is not recommended as the error messages indicate that there is problem in your setup. That is, you are attaching nvim-navic to servers that don't support documentSymbol or are attaching navic to multiple servers for a single buffer.
 
->NOTE: You can set `vim.b.navic_lazy_update_context = true` for specific buffers, where you want the the updates to not occur on every `CursorMoved` event. It should help if you are facing performance issues in large files. Read the docs for example usage of this variable.
+>NOTE: You can set `vim.b.navic_lazy_update_context = true` for specific buffers, where you want the the updates to not occur on every `CursorMoved` event. It should help if you are facing performance issues in large files. Read the docs for example usage of this variable. Alternatively, you can pass `lazy_update_context=true` to the `setup` function to turn off updates on the "CursorMoved" event completely.
 
 ## 🪄 Customise
 
@@ -78,6 +78,7 @@ Use the `setup` function to modify default parameters.
 * `highlight` : If set to true, will add colors to icons and text as defined by highlight groups `NavicIcons*` (`NavicIconsFile`, `NavicIconsModule`.. etc.), `NavicText` and `NavicSeparator`.
 * `depth_limit` : Maximum depth of context to be shown. If the context hits this depth limit, it is truncated.
 * `depth_limit_indicator` : Icon to indicate that `depth_limit` was hit and the shown context is truncated.
+* `lazy_update_context` : If true, turns off context updates for the "CursorMoved" event.
 * `safe_output` : Sanitize the output for use in statusline and winbar.
 * `click` : Single click to goto element, double click to open nvim-navbuddy on the clicked element.
 * `lsp` :
@@ -123,6 +124,7 @@ navic.setup {
     depth_limit = 0,
     depth_limit_indicator = "..",
     safe_output = true,
+    lazy_update_context = false,
     click = false
 }
 

--- a/doc/navic.txt
+++ b/doc/navic.txt
@@ -227,7 +227,14 @@ Use |navic.setup| to override any of the default options
 		the clicked element.
 	
 	lazy_update_context: boolean
-		If true, turns off context updates for the "CursorMoved" event.
+		If true, turns off context updates for the "CursorMoved" event,
+		updates will only happen on the "CursorHold" event. The
+		difference between this option and the vim.b.navic_lazy_update_context
+		variable is that this option turns off context updates on the
+		"CursorMoved" completely for all buffers, whereas the
+		vim.b.navic_lazy_update_context variable allows you to control that
+		behavior with more flexibility, like disabling context updates
+		depending on file size, total lines etc.
 
 	lsp :
 		auto_attach: boolean

--- a/doc/navic.txt
+++ b/doc/navic.txt
@@ -225,6 +225,9 @@ Use |navic.setup| to override any of the default options
 	click: boolean
 		Single click to goto element, double click to open nvim-navbuddy on
 		the clicked element.
+	
+	lazy_update_context: boolean
+		If true, turns off context updates for the "CursorMoved" event.
 
 	lsp :
 		auto_attach: boolean
@@ -278,6 +281,7 @@ Defaults >lua
 		depth_limit = 0,
 		depth_limit_indicator = "..",
 		safe_output = true,
+		lazy_update_context = false,
 		click = false
 	}
 <

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -39,6 +39,7 @@ local config = {
 	depth_limit = 0,
 	depth_limit_indicator = "..",
 	safe_output = true,
+	lazy_update_context = false,
 	click = false,
 	lsp = {
 		auto_attach = false,
@@ -124,6 +125,9 @@ function M.setup(opts)
 	end
 	if opts.safe_output ~= nil then
 		config.safe_output = opts.safe_output
+	end
+	if opts.lazy_update_context then
+		config.lazy_update_context = opts.lazy_update_context
 	end
 end
 
@@ -341,15 +345,17 @@ function M.attach(client, bufnr)
 		group = navic_augroup,
 		buffer = bufnr,
 	})
-	vim.api.nvim_create_autocmd("CursorMoved", {
-		callback = function()
-			if vim.b.navic_lazy_update_context ~= true then
-				lib.update_context(bufnr)
-			end
-		end,
-		group = navic_augroup,
-		buffer = bufnr,
-	})
+	if not config.lazy_update_context then
+		vim.api.nvim_create_autocmd("CursorMoved", {
+			callback = function()
+				if vim.b.navic_lazy_update_context ~= true then
+					lib.update_context(bufnr)
+				end
+			end,
+			group = navic_augroup,
+			buffer = bufnr,
+		})
+	end
 	vim.api.nvim_create_autocmd("BufDelete", {
 		callback = function()
 			lib.clear_buffer_data(bufnr)


### PR DESCRIPTION
This covers the case where I always want to have updates on the `CursorMoved` event turned off.
So, instead of setting `vim.b.navic_lazy_update_context` on every buffer and still firing the autocmds for that (`BufEnter` + `CursorMoved`), which is inefficient, I added the `lazy_update_context` property to the setup function that allows to turn off updates on the `CursorMoved` event by not setting the autocmd at all.