### PR TITLE
ref: extract data formatting into own function

### DIFF
--- a/doc/navic.txt
+++ b/doc/navic.txt
@@ -51,11 +51,11 @@ API                                                                 *navic-api*
 	buffer is used.
 
 *navic.format_data* (data, opts)
-    Formats data of the type returned by *navic.get_data* for use in the
-    statusline or winbar. This can be used to modify the raw data before
-    formatting it.
-    |opts| table can be passed to override any of |nvim-navic|'s options.
-    Follows same table format as *navic-setup*'s opts table.
+	Formats data of the type returned by *navic.get_data* for use in the
+	statusline or winbar. This can be used to modify the raw data before
+	formatting it.
+	|opts| table can be passed to override any of |nvim-navic|'s options.
+	Follows same table format as *navic-setup*'s opts table.
 
 =============================================================================
 Usage                                                             *navic-usage*

--- a/doc/navic.txt
+++ b/doc/navic.txt
@@ -51,7 +51,7 @@ API                                                                 *navic-api*
 	buffer is used.
 
 *navic.format_data* (data, opts)
-	Formats data of the type returned by *navic.get_data* for use in the
+	Formats data of the type returned by |navic.get_data| for use in the
 	statusline or winbar. This can be used to modify the raw data before
 	formatting it.
 	|opts| table can be passed to override any of |nvim-navic|'s options.

--- a/doc/navic.txt
+++ b/doc/navic.txt
@@ -50,6 +50,13 @@ API                                                                 *navic-api*
 	'bufnr' is optional argument. If bufnr is not provied, current open
 	buffer is used.
 
+*navic.format_data* (data, opts)
+    Formats data of the type returned by *navic.get_data* for use in the
+    statusline or winbar. This can be used to modify the raw data before
+    formatting it.
+    |opts| table can be passed to override any of |nvim-navic|'s options.
+    Follows same table format as *navic-setup*'s opts table.
+
 =============================================================================
 Usage                                                             *navic-usage*
 

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -288,7 +288,7 @@ end
 
 function M.get_location(opts, bufnr)
 	local data = M.get_data(bufnr)
-    return M.format_data(opts, data)
+	return M.format_data(opts, data)
 end
 
 local awaiting_lsp_response = {}

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -162,7 +162,11 @@ function M.is_available(bufnr)
 	return vim.b[bufnr].navic_client_id ~= nil
 end
 
-function M.get_location(opts, bufnr)
+function M.format_data(data, opts)
+	if data == nil then
+		return ""
+	end
+
 	local local_config = {}
 
 	if opts ~= nil then
@@ -198,11 +202,6 @@ function M.get_location(opts, bufnr)
 		local_config = config
 	end
 
-	local data = M.get_data(bufnr)
-
-	if data == nil then
-		return ""
-	end
 
 	local location = {}
 
@@ -285,6 +284,11 @@ function M.get_location(opts, bufnr)
 	end
 
 	return ret
+end
+
+function M.get_location(opts, bufnr)
+	local data = M.get_data(bufnr)
+    return M.format_data(opts, data)
 end
 
 local awaiting_lsp_response = {}


### PR DESCRIPTION
Hello!

Thank you for the plugin, it has been very pleasant to use.

### Motivation
When working in C++, I often find myself in nested namespaces two or three levels deep. Using nvim-navic's  native `get_location()` takes up quite a bit of my lualine in that scenario. To reduce some of that space usage, I wrote a function to parse `get_data()`'s output and combine namespace components into a single component. However, there was no way to format that data in the same way it would have been rendered by `get_location()`.

### Solution
This PR extracts formatting of the data into its own function such that a caller can format their own data in the same way that `get_location()` would.

### Example
<details>

<summary>lualine usage example for the namespace scenario discussed above</summary>

```lua
lualine.setup {
    sections = {
        lualine_c = {
            {
                -- Customized navic.get_location() that combines namespaces
                -- into a single string
                function()
                    local navic = require("nvim-navic")
                    local old_data = navic.get_data()
                    local new_data = {}
                    local cur_ns = nil
                    local ns_comps = {}

                    for _, comp in ipairs(old_data) do
                        if comp.type == "Namespace" then
                            cur_ns = comp
                            table.insert(ns_comps, comp.name)
                        else
                            -- On the first non-namespace component $c$, collect
                            -- previous NS components into a single one and
                            -- insert it in front of $c$.
                            if cur_ns ~= nil then
                                -- Concatenate name and insert
                                local num_comps = #ns_comps
                                local comb_name = ""
                                for idx = 1, num_comps do
                                    local ns_name = ns_comps[idx]

                                    -- No "::" in front of first component
                                    local join = (idx == 1) and "" or "::"

                                    if idx ~= num_comps then
                                        comb_name = comb_name .. join .. ns_name:sub(1, 1)
                                    else
                                        comb_name = comb_name .. join .. ns_name
                                    end
                                end

                                cur_ns.name = comb_name
                                table.insert(new_data, cur_ns)
                                cur_ns = nil
                            end

                            table.insert(new_data, comp)
                        end
                    end

                    return navic.format_data(new_data)
                end,
                cond = function()
                    return package.loaded["nvim-navic"]
                           and require("nvim-navic").is_available()
                end,
            },
        },
    },
}
```
</details>