### PR TITLE
Allow custom text formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Use the `setup` function to modify default parameters.
 * `highlight` : If set to true, will add colors to icons and text as defined by highlight groups `NavicIcons*` (`NavicIconsFile`, `NavicIconsModule`.. etc.), `NavicText` and `NavicSeparator`.
 * `depth_limit` : Maximum depth of context to be shown. If the context hits this depth limit, it is truncated.
 * `depth_limit_indicator` : Icon to indicate that `depth_limit` was hit and the shown context is truncated.
+* `format_text` : A function to customize the text displayed in each segment.
 * `lazy_update_context` : If true, turns off context updates for the "CursorMoved" event.
 * `safe_output` : Sanitize the output for use in statusline and winbar.
 * `click` : Single click to goto element, double click to open nvim-navbuddy on the clicked element.
@@ -125,7 +126,10 @@ navic.setup {
     depth_limit_indicator = "..",
     safe_output = true,
     lazy_update_context = false,
-    click = false
+    click = false,
+    format_text = function(text)
+        return text
+    end,
 }
 
 ```

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -1,9 +1,25 @@
 local lib = require("nvim-navic.lib")
 
+---@class LspOptions
+---@field auto_attach boolean
+---@field preference table | nil
+
+---@class Options
+---@field icons table | nil
+---@field highlight boolean | nil
+---@field format_text function | nil
+---@field depth_limit number | nil
+---@field depth_limit_indicator string | nil
+---@field lazy_update_context boolean | nil
+---@field safe_output boolean | nil
+---@field click boolean | nil
+---@field lsp LspOptions | nil
+
 -- @Public Methods
 
 local M = {}
 
+---@type Options
 local config = {
 	icons = {
 		[1] = "󰈙 ", -- File
@@ -44,7 +60,8 @@ local config = {
 	lsp = {
 		auto_attach = false,
 		preference = nil
-	}
+	},
+	format_text = function(a) return a end,
 }
 
 setmetatable(config.icons, {
@@ -94,6 +111,7 @@ local function setup_auto_attach(opts)
 	})
 end
 
+---@param opts Options
 function M.setup(opts)
 	if opts == nil then
 		return
@@ -128,6 +146,10 @@ function M.setup(opts)
 	end
 	if opts.lazy_update_context then
 		config.lazy_update_context = opts.lazy_update_context
+	end
+	if opts.format_text then
+		vim.validate({ format_text = { opts.format_text, "f" } })
+		config.format_text = opts.format_text
 	end
 end
 
@@ -211,7 +233,7 @@ function M.format_data(data, opts)
 			.. "#"
 			.. local_config.icons[kind]
 			.. "%*%#NavicText#"
-			.. name
+			.. config.format_text(name)
 			.. "%*"
 	end
 


### PR DESCRIPTION
Hi @SmiteshP, 

I've been enjoying your plugin for a while, and I would like to add customize the segments returned by the LSP client.

For example, when working with test suites, the navigation looks like

`describe('something') callback > describe ('subcategory') callback > it('can do things') callback`

The text is useful, but it can be a bit too verbose.

It would be great if we could shape the segments to be something like this:

`describe something > describe  subcategory > it can do things`

Which can be achieved by reading an optional `format_text` function to treat each segment of the result:

```lua
navic.setup({
  format_text = function(text)
    if (text:match("^it%(") or text:match("^describe%(")) then
      return text:gsub("^it%('", "it ")
                 :gsub("^describe%('", "describe ")
                 :gsub("'%) callback$", "")
    end
    return text
  end
})
```