### PR TITLE
fix: differently colored trailing cell in navic element

### DIFF
--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -283,7 +283,7 @@ function M.format_data(data, opts)
 		ret = table.concat(location, local_config.separator)
 	end
 
-	return ret
+	return string.gsub(ret, "%%%*$", "")
 end
 
 function M.get_location(opts, bufnr)


### PR DESCRIPTION
This fixes an issue where a single, differently colored cell is showing up in the status line.

I was having this problem that when I set up the highlights of navic to match those of my lualine, I got this:
![image](https://github.com/SmiteshP/nvim-navic/assets/9497302/9e40584f-b40b-4a27-973b-04a1ed249789)

After some searching I found out that this is caused by a trailing highlight reset (`%*`), which then causes the following padding added by lualine to be colored differently. When I disabled the right-side padding in my lualine config for this element, the problem also went away. So I figured you are not supposed to reset the final highlight of your lualine element. Thus this change simply removes the last highlight reset from the formatted element string.