### PR TITLE
Fix nvim-0.11 Deprecation Notices

### DIFF
--- a/lua/nvim-navic/lib.lua
+++ b/lua/nvim-navic/lib.lua
@@ -265,7 +265,14 @@ function M.request_symbol(for_buf, handler, client, file_uri, retry_count)
 		return
 	end
 
-	client.request("textDocument/documentSymbol", { textDocument = textDocument_argument }, function(err, symbols, _)
+	local function request(...)
+		if vim.fn.has('nvim-0.11') then
+			client:request(...)
+		else
+			client.request(...)
+		end
+	end
+	request("textDocument/documentSymbol", { textDocument = textDocument_argument }, function(err, symbols, _)
 		if symbols == nil then
 			if vim.api.nvim_buf_is_valid(for_buf) then
 				handler(for_buf, {})


### PR DESCRIPTION
On latest nvim, I'm getting:

![image](https://github.com/user-attachments/assets/5761fe9e-0994-456f-bf9c-85555e41956b)

Simply address the errors as instructed in `deprecated.txt`, using `client:request` instead of `client.request`.

***NOTE***: I'm not exactly sure which version of neovim this deprecation notice triggers on but I do believe `>=0.11` is fine. Just wanted to bring this implementation to your attention, I'm sure you can find a better implementation as well.
