### PR TITLE
Fix incorrect version select for nvim version < 0.11

### DIFF
--- a/lua/nvim-navic/lib.lua
+++ b/lua/nvim-navic/lib.lua
@@ -266,7 +266,7 @@ function M.request_symbol(for_buf, handler, client, file_uri, retry_count)
 	end
 
 	local function request(...)
-		if vim.fn.has('nvim-0.11') then
+		if vim.fn.has('nvim-0.11') == 1 then
 			client:request(...)
 		else
 			client.request(...)


### PR DESCRIPTION
The conditional statement would go into client:request(...) even though my nvim version was <0.11. This is now fixed.