### PR TITLE
Add CursorMovedI event to autocommand

### DIFF
--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -375,7 +375,7 @@ function M.attach(client, bufnr)
 		buffer = bufnr,
 	})
 	if not config.lazy_update_context then
-		vim.api.nvim_create_autocmd("CursorMoved", {
+		vim.api.nvim_create_autocmd({"CursorMoved", "CursorMovedI"}, {
 			callback = function()
 				if vim.b.navic_lazy_update_context ~= true then
 					lib.update_context(bufnr)


### PR DESCRIPTION
Add CursorMovedI when the ```lua azy_update_context = false``` so the breadcrumbs update on insert mode :)