### PR TITLE
docs: Update LSP configuration examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,13 @@ Example:
 ```lua
 local navic = require("nvim-navic")
 
-require("lspconfig").clangd.setup {
+vim.lsp.config('clangd', {
     on_attach = function(client, bufnr)
         navic.attach(client, bufnr)
     end
-}
+})
+
+vim.lsp.enable('clangd')
 ```
 
 If you're sharing your `on-attach` function between lspconfigs, better wrap nvim-navic's `attach` function to make sure `documentSymbolProvider` is enabled:
@@ -61,9 +63,11 @@ local on_attach = function(client, bufnr)
     ...
 end
 
-require("lspconfig").clangd.setup {
+vim.lsp.config('clangd', {
     on_attach = on_attach
-}
+})
+
+vim.lsp.enable('clangd')
 ```
 
 >NOTE: You can set `vim.g.navic_silence = true` to supress error messages thrown by nvim-navic. However this is not recommended as the error messages indicate that there is problem in your setup. That is, you are attaching nvim-navic to servers that don't support documentSymbol or are attaching navic to multiple servers for a single buffer.


### PR DESCRIPTION
## Issue
After upgrading nvim-lspconfig to the latest version (https://github.com/neovim/nvim-lspconfig/tree/d696e36d5792daf828f8c8e8d4b9aa90c1a10c2a), the original way of setting up nvim-navic will show the following warning when we start nvim:
```
The `require('lspconfig')` "framework" is deprecated, use vim.lsp.config (see :help lspconfig-nvim-0.11) instead.
Feature will be removed in nvim-lspconfig v3.0.0
stack traceback:
        ...ocal/share/nvim/plugged/nvim-lspconfig/lua/lspconfig.lua:81: in function '__index'
        [string ":lua"]:55: in main chunk
```

## How to reproduce this issue
1. Update nvim-lspconfig to the latest version with your nvim plugin manager.
2. Make sure nvim-navic is setup using the original method in the nvim config file
3. Launch nvim, and the above warning will be shown.

## Results
Confirmed to work on my machine.

<img width="903" height="292" alt="Screenshot 2025-12-28 at 7 50 17 PM" src="https://github.com/user-attachments/assets/b3303675-4de5-4c07-922b-24e6692824d7" />