### PR TITLE
feat: Add support for coc.nvim

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Named after the Indian satellite navigation system.
 ## ⚡️ Requirements
 
 * Neovim >= 0.7.0
-* [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig)
+* [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) or [coc.nvim](https://github.com/neoclide/coc.nvim)
 
 ## 📦 Installation
 
@@ -70,6 +70,20 @@ vim.lsp.config('clangd', {
 vim.lsp.enable('clangd')
 ```
 
+### coc.nvim
+
+If you use [coc.nvim](https://github.com/neoclide/coc.nvim) instead of the builtin LSP client, enable the `coc.auto_attach` option and nvim-navic will attach to buffers that have a coc documentSymbol provider:
+
+```lua
+require("nvim-navic").setup {
+    coc = {
+        auto_attach = true,
+    },
+}
+```
+
+Alternatively you can attach manually with `navic.attach_coc(bufnr)`, for example from an autocommand of your choosing.
+
 >NOTE: You can set `vim.g.navic_silence = true` to supress error messages thrown by nvim-navic. However this is not recommended as the error messages indicate that there is problem in your setup. That is, you are attaching nvim-navic to servers that don't support documentSymbol or are attaching navic to multiple servers for a single buffer.
 
 >NOTE: You can set `vim.b.navic_lazy_update_context = true` for specific buffers, where you want the the updates to not occur on every `CursorMoved` event. It should help if you are facing performance issues in large files. Read the docs for example usage of this variable. Alternatively, you can pass `lazy_update_context=true` to the `setup` function to turn off context updates on the `CursorMoved` event completely for all buffers. It's useful when you just want context updates to happen only on `CursorHold` events and not on `CursorMoved`.
@@ -90,6 +104,8 @@ Use the `setup` function to modify default parameters.
 * `lsp` :
     * `auto_attach` : Enable to have nvim-navic automatically attach to every LSP for current buffer. Its disabled by default.
     * `preference` : Table ranking lsp_servers. Lower the index, higher the priority of the server. If there are more than one server attached to a buffer, nvim-navic will refer to this list to make a decision on which one to use. For example - In case a buffer is attached to clangd and ccls both and the preference list is `{ "clangd", "pyright" }`. Then clangd will be preferred.
+* `coc` :
+    * `auto_attach` : Enable to have nvim-navic automatically attach to buffers handled by coc.nvim. Its disabled by default.
 
 ```lua
 navic.setup {
@@ -125,6 +141,9 @@ navic.setup {
     lsp = {
         auto_attach = false,
         preference = nil,
+    },
+    coc = {
+        auto_attach = false,
     },
     highlight = false,
     separator = " > ",

--- a/doc/navic.txt
+++ b/doc/navic.txt
@@ -28,6 +28,13 @@ API                                                                 *navic-api*
 	Used to attach |nvim-navic| to lsp server. Pass this function as
 	on_attach while setting up your desired lsp server.
 
+*navic.attach_coc* (bufnr)
+	Used to attach |nvim-navic| to coc.nvim for the given buffer. Requires
+	coc.nvim to be running. You can skip calling this function if you have
+	enabled the coc auto_attach option during setup.
+	'bufnr' is optional argument. If bufnr is not provied, current open
+	buffer is used.
+
 *navic.is_available* (bufnr)
 	Returns boolean value indicating whether |nvim-navic| is able to provide
 	output for current buffer.
@@ -71,6 +78,16 @@ Example: >lua
 		on_attach = function(client, bufnr)
 			navic.attach(client, bufnr)
 		end
+	}
+<
+
+If you use coc.nvim instead of the builtin lsp client, enable the coc
+auto_attach option (or call |navic.attach_coc| yourself):
+>lua
+	require("nvim-navic").setup {
+		coc = {
+			auto_attach = true,
+		},
 	}
 <
 
@@ -258,6 +275,11 @@ Use |navic.setup| to override any of the default options
 			and the preference list is `{ "clangd", "pyright" }`. Then clangd
 			will be preferred.
 
+	coc :
+		auto_attach: boolean
+			Enable to have nvim-navic automatically attach to buffers handled
+			by coc.nvim. Its disabled by default.
+
 Defaults >lua
 	navic.setup {
 		icons = {
@@ -292,6 +314,9 @@ Defaults >lua
 		lsp = {
 			auto_attach = false,
 			preference = nil,
+		},
+		coc = {
+			auto_attach = false,
 		},
 		highlight = false,
 		separator = " > ",

--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -4,6 +4,9 @@ local lib = require("nvim-navic.lib")
 ---@field auto_attach boolean
 ---@field preference table | nil
 
+---@class CocOptions
+---@field auto_attach boolean
+
 ---@class Options
 ---@field icons table | nil
 ---@field highlight boolean | nil
@@ -14,6 +17,7 @@ local lib = require("nvim-navic.lib")
 ---@field safe_output boolean | nil
 ---@field click boolean | nil
 ---@field lsp LspOptions | nil
+---@field coc CocOptions | nil
 
 -- @Public Methods
 
@@ -61,6 +65,9 @@ local config = {
 	lsp = {
 		auto_attach = false,
 		preference = nil
+	},
+	coc = {
+		auto_attach = false
 	},
 	format_text = function(a) return a end,
 }
@@ -112,6 +119,34 @@ local function setup_auto_attach(opts)
 	})
 end
 
+local function setup_coc_auto_attach()
+	-- coc.nvim does not have an equivalent of the LspAttach event, and
+	-- extensions register their symbol providers asynchronously. Keep
+	-- checking for a documentSymbol provider until one shows up.
+	vim.api.nvim_create_autocmd({ "BufEnter", "CursorHold", "CursorHoldI" }, {
+		callback = function(args)
+			local bufnr = args.buf
+			if vim.b[bufnr].navic_client_id ~= nil then
+				return
+			end
+			if vim.g.coc_service_initialized ~= 1 or vim.bo[bufnr].buftype ~= "" then
+				return
+			end
+			-- hasProvider only works on the current buffer
+			vim.fn.CocActionAsync("hasProvider", "documentSymbol", function(err, has_provider)
+				if
+					(err == nil or err == vim.NIL)
+					and has_provider == true
+					and vim.api.nvim_get_current_buf() == bufnr
+					and vim.b[bufnr].navic_client_id == nil
+				then
+					M.attach_coc(bufnr)
+				end
+			end)
+		end,
+	})
+end
+
 ---@param opts Options
 function M.setup(opts)
 	if opts == nil then
@@ -120,6 +155,10 @@ function M.setup(opts)
 
 	if opts.lsp ~= nil and opts.lsp.auto_attach then
 		setup_auto_attach(opts)
+	end
+
+	if opts.coc ~= nil and opts.coc.auto_attach then
+		setup_coc_auto_attach()
 	end
 
 	if opts.icons ~= nil then
@@ -336,33 +375,9 @@ local function lsp_callback(for_buf, symbols)
 	lib.update_data(for_buf, symbols)
 end
 
-function M.attach(client, bufnr)
-	if not client.server_capabilities.documentSymbolProvider then
-		if not vim.g.navic_silence then
-			vim.notify(
-				'nvim-navic: Server "' .. client.name .. '" does not support documentSymbols.',
-				vim.log.levels.ERROR
-			)
-		end
-		return
-	end
-
-	if vim.b[bufnr].navic_client_id ~= nil and vim.b[bufnr].navic_client_name ~= client.name then
-		local prev_client = vim.b[bufnr].navic_client_name
-		if not vim.g.navic_silence then
-			vim.notify(
-				"nvim-navic: Failed to attach to "
-					.. client.name
-					.. " for current buffer. Already attached to "
-					.. prev_client,
-				vim.log.levels.WARN
-			)
-		end
-		return
-	end
-
-	vim.b[bufnr].navic_client_id = client.id
-	vim.b[bufnr].navic_client_name = client.name
+-- Set up the autocmds for a buffer and make the first symbol request.
+-- request_fn is called as request_fn(bufnr, lsp_callback) to fetch symbols.
+local function setup_buffer(bufnr, request_fn)
 	local changedtick = 0
 
 	local navic_augroup = vim.api.nvim_create_augroup("navic", { clear = false })
@@ -375,7 +390,7 @@ function M.attach(client, bufnr)
 			if not awaiting_lsp_response[bufnr] and changedtick < vim.b[bufnr].changedtick then
 				awaiting_lsp_response[bufnr] = true
 				changedtick = vim.b[bufnr].changedtick
-				lib.request_symbol(bufnr, lsp_callback, client)
+				request_fn(bufnr, lsp_callback)
 			end
 		end,
 		group = navic_augroup,
@@ -409,7 +424,68 @@ function M.attach(client, bufnr)
 
 	-- First call
 	vim.b[bufnr].navic_awaiting_lsp_response = true
-	lib.request_symbol(bufnr, lsp_callback, client)
+	request_fn(bufnr, lsp_callback)
+end
+
+function M.attach(client, bufnr)
+	if not client.server_capabilities.documentSymbolProvider then
+		if not vim.g.navic_silence then
+			vim.notify(
+				'nvim-navic: Server "' .. client.name .. '" does not support documentSymbols.',
+				vim.log.levels.ERROR
+			)
+		end
+		return
+	end
+
+	if vim.b[bufnr].navic_client_id ~= nil and vim.b[bufnr].navic_client_name ~= client.name then
+		local prev_client = vim.b[bufnr].navic_client_name
+		if not vim.g.navic_silence then
+			vim.notify(
+				"nvim-navic: Failed to attach to "
+					.. client.name
+					.. " for current buffer. Already attached to "
+					.. prev_client,
+				vim.log.levels.WARN
+			)
+		end
+		return
+	end
+
+	vim.b[bufnr].navic_client_id = client.id
+	vim.b[bufnr].navic_client_name = client.name
+
+	setup_buffer(bufnr, function(for_buf, callback)
+		lib.request_symbol(for_buf, callback, client)
+	end)
+end
+
+function M.attach_coc(bufnr)
+	bufnr = bufnr or vim.api.nvim_get_current_buf()
+
+	if vim.fn.exists("*CocActionAsync") == 0 then
+		if not vim.g.navic_silence then
+			vim.notify("nvim-navic: coc.nvim is not available.", vim.log.levels.ERROR)
+		end
+		return
+	end
+
+	if vim.b[bufnr].navic_client_id ~= nil and vim.b[bufnr].navic_client_name ~= "coc" then
+		local prev_client = vim.b[bufnr].navic_client_name
+		if not vim.g.navic_silence then
+			vim.notify(
+				"nvim-navic: Failed to attach to coc for current buffer. Already attached to " .. prev_client,
+				vim.log.levels.WARN
+			)
+		end
+		return
+	end
+
+	-- coc.nvim does not expose a client id, use -1 to mark the buffer as attached
+	vim.b[bufnr].navic_client_id = -1
+	vim.b[bufnr].navic_client_name = "coc"
+
+	setup_buffer(bufnr, lib.request_coc_symbol)
 end
 
 return M

--- a/lua/nvim-navic/lib.lua
+++ b/lua/nvim-navic/lib.lua
@@ -455,4 +455,70 @@ function M.adapt_lsp_num_to_str(n)
 	return lsp_num_to_str[n]
 end
 
+-- coc.nvim's documentSymbols action returns a flat list of symbols where
+-- nesting is expressed through the "level" field. Convert it back into the
+-- hierarchical DocumentSymbol format that M.parse understands.
+local function coc_to_document_symbols(coc_symbols)
+	local root = { children = {} }
+	local stack = { root }
+
+	for _, symbol in ipairs(coc_symbols) do
+		if type(symbol) == "table" and symbol.range ~= nil then
+			local node = {
+				name = symbol.text,
+				kind = lsp_str_to_num[symbol.kind],
+				range = symbol.range,
+				-- deepcopy since M.parse modifies ranges in place
+				selectionRange = symbol.selectionRange or vim.deepcopy(symbol.range),
+			}
+
+			local level = symbol.level or 0
+			while #stack > level + 1 do
+				table.remove(stack)
+			end
+
+			local parent = stack[#stack]
+			if parent.children == nil then
+				parent.children = {}
+			end
+			table.insert(parent.children, node)
+			table.insert(stack, node)
+		end
+	end
+
+	return root.children
+end
+
+-- Make request to coc.nvim
+function M.request_coc_symbol(for_buf, handler, retry_count)
+	if retry_count == nil then
+		retry_count = 10
+	elseif retry_count == 0 then
+		handler(for_buf, {})
+		return
+	end
+
+	if not vim.api.nvim_buf_is_loaded(for_buf) then
+		return
+	end
+
+	vim.fn.CocActionAsync("documentSymbols", for_buf, function(err, symbols)
+		if err ~= nil and err ~= vim.NIL then
+			if vim.api.nvim_buf_is_valid(for_buf) then
+				vim.defer_fn(function()
+					M.request_coc_symbol(for_buf, handler, retry_count - 1)
+				end, 750)
+			end
+		elseif symbols == nil or symbols == vim.NIL then
+			if vim.api.nvim_buf_is_valid(for_buf) then
+				handler(for_buf, {})
+			end
+		else
+			if vim.api.nvim_buf_is_loaded(for_buf) then
+				handler(for_buf, coc_to_document_symbols(symbols))
+			end
+		end
+	end)
+end
+
 return M


### PR DESCRIPTION
We could previously only get document symbols through Neovim's builtin LSP client. This adds a second request path that uses coc.nvim's "documentSymbols" action.

New API:
- `navic.attach_coc(bufnr)` to attach manually
- `coc = { auto_attach = true }` setup option, which attaches to buffers once Coc reports a documentSymbol provider for them.

Note that Coc has no LspAttach equivalent, and providers register asynchronously, so this polls hasProvider on BufEnter/CursorHold until one shows up.

The buffer is marked with _navic_client_name = "coc"_, so `is_available()`, the lualine component, and the one-client-per-buffer conflict handling all work unchanged.

Closes SmiteshP/nvim-navic#53