### PR TITLE
fix(validate): use positional form on Neovim 0.11

### DIFF
--- a/lua/nvim-navic/init.lua
+++ b/lua/nvim-navic/init.lua
@@ -154,7 +154,11 @@ function M.setup(opts)
 		config.click = opts.click
 	end
 	if opts.format_text then
-		vim.validate({ format_text = { opts.format_text, "f" } })
+		if vim.fn.has("nvim-0.11") == 1 then
+			vim.validate("format_text", opts.format_text, "function")
+		else
+			vim.validate({ format_text = { opts.format_text, "f" } })
+		end
 		config.format_text = opts.format_text
 	end
 end


### PR DESCRIPTION
## Summary

Use the positional `vim.validate` form on Neovim 0.11 and newer.

## Why

[Neovim 0.11 deprecates table-form validation](https://neovim.io/doc/user/deprecated/#deprecated-0.11), but nvim-navic still supports Neovim
0.7.

## What changed

- Added a version gate around `format_text` validation.
- Retained table-form validation on older supported releases.
- Preserved the existing validation errors.

## Testing

- Function and invalid-value probes passed on Neovim 0.7.0, 0.11.2, and 0.13
  nightly.
- Module loading and diff checks passed.

## Related Issue(s)

- None.
